### PR TITLE
Additions for non-haproxy (e.g. mcrouter) service discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,9 @@ use discovery information but not go through HAProxy.
 
 * `output_directory`: the path to a directory on disk that service registrations
 should be written to.
+* `reload_command`: a command to run after the JSON file is updated. the
+%{service_name} and %{service_json} template parameters will be replaced with
+the name of the service and the path to the json file respectively.
 
 
 ### HAProxy shared HTTP Frontend ###

--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -20,9 +20,11 @@ module Synapse
 
       # create objects that need to be notified of service changes
       @config_generators = []
-      # create the haproxy config generator, this is mandatory
-      raise "haproxy config section is missing" unless opts.has_key?('haproxy')
-      @config_generators << Haproxy.new(opts['haproxy'])
+
+      # possibly create an haproxy config generator
+      if opts.has_key?('haproxy')
+        @config_generators << Haproxy.new(opts['haproxy'])
+      end
 
       # possibly create a file manifestation for services that do not
       # want to communicate via haproxy, e.g. cassandra


### PR DESCRIPTION
We'll still use the haproxy stuff for most things, but sometimes there are smarter clients that need service discovery but can't go through haproxy (e.g. mcrouter or token-aware cassandra drivers). These tweaks additions do two things in aid of that:
- make the haproxy config generator optional so we don't need to install and configure it on servers that don't care
- add an optional command to run after the file output is generated, we can use this to trigger generation of a full mcrouter config for example

:eyeglasses: @bsimpson63 @ckwang8128
