### PR TITLE
Add config generator for Envoy

### DIFF
--- a/lib/synapse.rb
+++ b/lib/synapse.rb
@@ -33,6 +33,11 @@ module Synapse
         @config_generators << ConfigGenerator::Haproxy.new(opts['haproxy'])
       end
 
+      # possibly create an envoy config generator
+      if opts.has_key?('envoy')
+        @config_generators << ConfigGenerator::Envoy.new(opts['envoy'])
+      end
+
       # possibly create a file manifestation for services that do not
       # want to communicate via haproxy, e.g. cassandra
       if opts.has_key?('file_output')

--- a/lib/synapse/config_generator/envoy.rb
+++ b/lib/synapse/config_generator/envoy.rb
@@ -1,0 +1,389 @@
+require 'synapse/config_generator/base'
+
+require 'fileutils'
+require 'json'
+require 'socket'
+require 'digest/sha1'
+require 'set'
+require 'hashdiff'
+require 'yaml'
+
+class Synapse::ConfigGenerator
+  class Envoy < BaseGenerator
+    include Synapse::Logging
+
+    NAME = 'envoy'.freeze
+
+    # These come from documentation for Envoy (1.6)
+
+    SECTION_FIELDS = [
+      'listeners' => {
+      },
+      'clusters' => {
+      },
+      'admin' => [
+        'access_log_path',
+      ],
+    ].freeze
+
+    DEFAULT_STATE_FILE_TTL = (60 * 60 * 24).freeze #24 hours
+    STATE_FILE_UPDATE_INTERVAL = 60.freeze # iterations; not a unit of time
+    DEFAULT_BIND_ADDRESS = '127.0.0.1'
+
+    attr_reader :state_cache
+
+    def initialize(opts)
+      super(opts)
+
+      #%w{global defaults}.each do |req|
+      # raise ArgumentError, "Envoy requires a #{req} section" if !opts.has_key?(req)
+     # end
+
+      # Default opts
+      @opts['do_writes'] = true unless @opts.key?('do_writes')
+      @opts['do_reloads'] = true unless @opts.key?('do_reloads')
+
+      # how to restart envoy
+      @restart_interval = @opts.fetch('restart_interval', 2).to_i
+      @restart_jitter = @opts.fetch('restart_jitter', 0).to_f
+      @restart_required = true
+
+      # TODO HERE: PUT TOGETHER ALL THE HOT RELOAD CONFIGURATIONS
+      @reload_command = ""
+
+      # virtual clock bookkeeping for controlling how often envoy restarts
+      @time = 0
+      @next_restart = @time
+
+      @admin_configs = {
+        'access_log_path' => @opts.fetch('admin_log_path', '/dev/null'),
+        'admin_socket_addr' => @opts.fetch('admin_socket_addr', '127.0.0.1'),
+        'admin_port_value' => @opts.fetch('admin_port_value', '8001'),
+      }
+      # a place to store the parsed envoy config from each watcher
+      # This is the config stanza in `/etc/synapse.d/<service.yaml>`, e.g.
+      # envoy:
+      #   bind_address: "127.0.103.1"
+      #   port: 9090
+      #   server_options: "check"
+      #   listen:
+      #    - "mode tcp"
+      @watcher_configs = {}
+
+      # a place to store generated listeners and clusters stanzas
+      @listeners_cache = {}
+      @clusters_cache = {}
+      @watcher_revisions = {}
+    end
+
+    def normalize_watcher_provided_config(service_watcher_name, service_watcher_config)
+      service_watcher_config = super(service_watcher_name, service_watcher_config)
+
+      defaults = {
+      }
+
+      unless service_watcher_config.include?('port')
+        log.warn "synapse: service #{service_watcher_name}: Envoy config does not include a port; only cluster sections for the service will be created. You will need to define a listener section manually."
+      end
+
+      defaults.merge(service_watcher_config)
+    end
+
+    # split the envoy config in each watcher into fields applicable in
+    # frontend and backend sections
+    def parse_watcher_config(watcher)
+    end
+
+    # TODO: Verify if the restart required is needed.
+    def tick(watchers)
+      if (@time % STATE_FILE_UPDATE_INTERVAL) == 0
+        update_state_file(watchers)
+      end
+
+      @time += 1
+
+      # We potentially have to restart if the restart was rate limited
+      # in the original call to update_config
+      restart if opts['do_reloads'] && @restart_required
+    end
+
+    def update_config(watchers)
+      # if we support updating backends, try that whenever possible
+      #if opts['do_socket']
+#        opts['socket_file_paths'].each do |socket_path|
+ #         update_backends_at(socket_path, watchers)
+    #end
+    #else
+      #@restart_required = true
+    #end
+
+      # generate a new config
+      new_config = generate_config(watchers)
+
+      # if we write config files, lets do that and then possibly restart
+      if opts['do_writes']
+        write_config(new_config)
+        restart if opts['do_reloads'] && @restart_required
+      end
+    end
+
+    def update_state_file(watchers)
+      #@state_cache.update_state_file(watchers)
+    end
+
+    def generate_admin_config
+      admin_config = {
+        'access_log_path' => @admin_configs['access_log_path'],
+        'address' => {
+          'socket_address' => {
+            'address' => @admin_configs['admin_socket_addr'],
+            'port_value' => @admin_configs['admin_port_value'],
+          },
+        },
+      }
+      return admin_config
+    end
+
+    def generate_base_config
+      base_config = {
+        'static_resources' => {
+          'listeners' => [],
+          'clusters' => [],
+        },
+        'admin' => generate_admin_config,
+      }
+      return base_config
+    end
+
+    def generate_listeners_stanza(watcher, config)
+      watcher_config = watcher.config_for_generator[name]
+
+      unless watcher_config.has_key?("port")
+        log.debug("synapse: not generating listener stanza for watcher #{watcher.name} because it has no port defined")
+        return {}
+      else
+        port = watcher_config['port']
+      end
+
+      bind_address = (
+        watcher_config['bind_address'] || DEFAULT_BIND_ADDRESS
+      )
+      cluster_name = watcher_config.fetch('backend_name', watcher.name)
+
+      listener_config = watcher_config.fetch('listener', {})
+      filter_configs = {}
+
+      if not listener_config.empty?
+        filter_list = listener_config.fetch('filters', [])
+
+        filter_list.each do | filter |
+          filter.each do |filter_name, filter_config|
+            filter_configs[filter_name] = filter_config
+          end
+        end
+      end
+
+      default_tcp_config = {
+        'stat_prefix' => 'ingress_tcp',
+        'max_connect_attempts' => 3,
+        'idle_timeout' => '60s',
+      }
+
+      tcp_config = default_tcp_config.merge(filter_configs.fetch('tcp', {}))
+
+      # Explicit null value passed indicating no port needed
+      # For example if the bind_address is a unix port
+      # TODO: FIGURE OUT WHAT THIS NEEDS TO BE TO SUPPORT UNIX CONFIGURATION
+      bind_port = port.nil? ? '' : "#{port}"
+
+      stanza = {
+        'address' => {
+          'socket_address' => {
+            'address' => bind_address,
+            'port_value' => bind_port
+          }
+        },
+        'filter_chains' => [
+          'filters' => [
+            {
+              'name' => 'envoy.tcp_proxy',
+              'config' => {
+                'stat_prefix' => tcp_config.fetch('stat_prefix', 'ingress_tcp'),
+                'max_connect_attempts' => tcp_config.fetch('max_connect_attempts', 3),
+                'idle_timeout' => tcp_config.fetch('idle_timeout', '60s'),
+                'cluster' => cluster_name,
+                'access_log' => [
+                  'name' => 'envoy.file_access_log',
+                  'config' => {
+                    'path' => '/var/log/envoy.log',
+                  }
+                ]
+              }
+            }
+          ]
+        ]
+      }
+
+      return stanza
+    end
+
+    def generate_clusters_stanza(watcher, config)
+      if watcher.backends.empty?
+        log.debug "synapse: no backends found for watcher #{watcher.name}"
+      end
+
+      watcher_config = watcher.config_for_generator[name]
+
+      cluster_config = watcher_config.fetch('cluster', {})
+
+      host_list = []
+      watcher.backends.each do | backend |
+        backend_entry = {}
+        backend_entry['socket_address'] = {
+          'address' => backend['host'],
+          'port_value' => backend['port'],
+        }
+        host_list << backend_entry
+      end
+
+      # Write the cluster stanza for Envoy now
+      stanza = {
+        'name' => watcher.name,
+        'connect_timeout' => cluster_config.fetch('connect_timeout', '1s'),
+        'type' => cluster_config.fetch('type', 'strict_dns'),
+        'lb_policy' => cluster_config.fetch('lb_policy', 'least_request'),
+        'hosts' => host_list,
+        'health_checks' => [generate_health_check_config(cluster_config)],
+      }
+      return stanza
+    end
+
+    def generate_health_check_config(cluster_config)
+      # Only possible to generate TCP health checks right now.
+      health_check_config = cluster_config.fetch('health_check', {})
+      return {
+          'timeout' => health_check_config.fetch('timeout', '1s'),
+          'interval' => health_check_config.fetch('interval', '2s'),
+          'unhealthy_threshold' => health_check_config.fetch('unhealthy_threshold', 2),
+          'healthy_threshold' => health_check_config.fetch('healthy_threshold', 3),
+          'tcp_health_check' => {
+            'send' => nil,
+            'receive' => nil,
+          },
+      }
+    end
+
+    # Generate a new Envoy config based on the state of the watchers
+    def generate_config(watchers)
+      new_config = generate_base_config
+      watchers.each do |watcher|
+        watcher_config = watcher.config_for_generator[name]
+        next if watcher_config.nil? || watcher_config.empty? || watcher_config['disabled']
+        @watcher_configs[watcher.name] = parse_watcher_config(watcher)
+        #if watcher_config is changed, trigger restart
+        #config_diff = HashDiff.diff(@state_cache.config_for_generator(watcher.name, watcher_config))
+        #if !config_diff.empty?
+          #log.info "synapse: restart required because config_for_generator changed. before: #{@state_cache.config_for_generator(watcher.name)}, after: #{watcher_config}"
+          #@restart_required = true
+  #      end
+
+        regenerate = watcher.revision != @watcher_revisions[watcher.name] ||
+                     @listeners_cache[watcher.name].nil? ||
+                     @clusters_cache[watcher.name].nil?
+
+        if regenerate
+          @listeners_cache[watcher.name] = generate_listeners_stanza(watcher, @watcher_configs[watcher.name])
+          @clusters_cache[watcher.name] = generate_clusters_stanza(watcher, @watcher_configs[watcher.name])
+          @watcher_revisions[watcher.name] = watcher.revision
+        end
+
+      end
+
+      @listeners_cache.each do | watcher_name, listener_stanza |
+        new_config['static_resources']['listeners'] << listener_stanza
+      end
+      # Write all the clusters
+      @clusters_cache.each do | watcher_name, cluster_stanza |
+        new_config['static_resources']['clusters'] << cluster_stanza
+      end
+      return new_config
+    end
+
+    def write_config(new_config)
+      # new_config is giant hash
+      begin
+        old_config = File.read(opts['config_file_path'])
+      rescue Errno::ENOENT => e
+        log.error "synapse: could not open Envoy config file at #{opts['config_file_path']}"
+        old_config = ""
+      end
+
+      if old_config == new_config
+        return false
+      else
+        tmp_file_path = "#{opts['config_file_path']}.tmp"
+        # Write YAML out from new_config hash
+        File.write(tmp_file_path, new_config.to_yaml)
+        FileUtils.mv(tmp_file_path, opts['config_file_path'])
+        return true
+      end
+    end
+
+    # used to build unique, consistent envoy cluster names
+    def construct_name(backend)
+      name = "#{backend['host']}:#{backend['port']}"
+      if backend['name'] && !backend['name'].empty?
+        name = "#{backend['name']}_#{name}"
+      end
+      return name
+    end
+
+    # restarts Envoy if the time is right
+    def restart
+      if @time < @next_restart
+        log.info "synapse: at time #{@time} waiting until #{@next_restart} to restart"
+        return
+      end
+
+      @next_restart = @time + @restart_interval
+      @next_restart += rand(@restart_jitter * @restart_interval + 1)
+
+      # do the actual restart
+      res = `#{opts['reload_command']}`.chomp
+      unless $?.success?
+        log.error "failed to reload envoy via #{opts['reload_command']}: #{res}"
+        return
+      end
+      log.info "synapse: restarted envoy"
+
+      @restart_required = false
+    end
+
+
+    ######################################
+    # methods for managing the state file
+    ######################################
+    class EnvoyState
+      include Synapse::Logging
+      # TODO: enable version in the Envoy Cache File
+      KEY_WATCHER_CONFIG_FOR_GENERATOR = "watcher_config_for_generator"
+      NON_BACKENDS_KEYS = [KEY_WATCHER_CONFIG_FOR_GENERATOR]
+
+      # Params:
+      # +state_file_path+:: path to write state file to
+      # +state_file_ttl+:: ttl for state file
+      # +envoy+:: Envoy config generator
+      def initialize(state_file_path, state_file_ttl, envoy)
+        @state_file_path = state_file_path
+        @state_file_ttl = state_file_ttl
+        @envoy = envoy
+      end
+
+      def backends(watcher_name)
+        if seen.key?(watcher_name)
+          seen[watcher-name]
+        end
+      end
+    end
+  end
+end

--- a/spec/bin/synapse_spec.rb
+++ b/spec/bin/synapse_spec.rb
@@ -20,7 +20,10 @@ describe 'parseconfig' do
               {"port" => 3219,
                "bind_address" => "localhost",
                "server_options" => ["some_haproxy_server_option"],
-               "listen" => ["some_haproxy_listen_option"]}}},
+               "listen" => ["some_haproxy_listen_option"]},
+             "envoy" =>
+              {"port" => 9090,
+               "bind_address" => "localhost"}}},
          "haproxy" =>
           {"reload_command" => "sudo service haproxy reload",
            "config_file_path" => "/etc/haproxy/haproxy.cfg",

--- a/spec/lib/synapse/envoy_spec.rb
+++ b/spec/lib/synapse/envoy_spec.rb
@@ -1,0 +1,134 @@
+require 'spec_helper'
+require 'synapse/config_generator/envoy'
+
+class MockWatcher; end;
+
+describe Synapse::ConfigGenerator::Envoy do
+  subject { Synapse::ConfigGenerator::Envoy.new(config['envoy']) }
+
+  let(:mockwatcher) do
+    mockWatcher = double(Synapse::ServiceWatcher)
+    allow(mockWatcher).to receive(:name).and_return('example_service')
+    backends = [{ 'host' => 'somehost', 'port' => 5555}]
+    allow(mockWatcher).to receive(:backends).and_return(backends)
+    allow(mockWatcher).to receive(:config_for_generator).and_return({
+      'envoy' => {},
+    })
+    allow(mockWatcher).to receive(:revision).and_return(1)
+    mockWatcher
+  end
+
+  let(:mockwatcher_frontend) do
+    mockWatcher = double(Synapse::ServiceWatcher)
+    allow(mockWatcher).to receive(:name).and_return('example_service4')
+    allow(mockWatcher).to receive(:config_for_generator).and_return({
+      'envoy' => {'port' => 9090}
+    })
+    allow(mockWatcher).to receive(:revision).and_return(1)
+    mockWatcher
+  end
+
+  let(:mockwatcher_frontend_with_bind_address) do
+    mockWatcher = double(Synapse::ServiceWatcher)
+    allow(mockWatcher).to receive(:name).and_return('example_service5')
+    backends = [
+      { 'host' => 'somehost', 'port' => 5555},
+      { 'host' => 'somehost2','port' => 5555},
+    ]
+    allow(mockWatcher).to receive(:backends).and_return(backends)
+    allow(mockWatcher).to receive(:config_for_generator).and_return({
+      'envoy' => {'port' => 9090, 'bind_address' => "127.0.0.3"}
+    })
+    allow(mockWatcher).to receive(:revision).and_return(1)
+    mockWatcher
+  end
+
+  describe '#initialize' do
+    it 'succeeds on minimal config' do
+      conf = {
+        'global' => [],
+        'defaults' => [],
+        'do_writes' => false,
+        'do_reloads' => false,
+        'do_socket' => false
+      }
+      Synapse::ConfigGenerator::Envoy.new(conf)
+      expect{Synapse::ConfigGenerator::Envoy.new(conf)}.not_to raise_error
+    end
+  end
+
+  describe '#name' do
+    it 'returns envoy' do
+      expect(subject.name).to eq('envoy')
+    end
+  end
+
+  describe 'basic operations' do
+    it 'generates listener stanza' do
+      mockConfig = []
+      expect(subject.
+               generate_listeners_stanza(mockwatcher_frontend_with_bind_address, mockConfig)).
+        to eql({
+        'address' => {
+          'socket_address' => {
+            'address' => '127.0.0.3',
+            'port_value' => '9090',
+          }
+        },
+        'filter_chains' => {
+          'filters' => [
+            {
+              'name' => 'envoy.tcp_proxy',
+              'config' => {
+                'stat_prefix' => 'ingress_tcp',
+                'cluster' => 'example_service5',
+                'access_log' => {
+                  'name' => 'envoy.file_access_log',
+                  'config' => {
+                    'path' => '/var/log/envoy',
+                  }
+                }
+              }
+            }
+          ]
+        }
+      })
+    end
+
+    it 'does not generate stanza if no port defined' do
+      mockConfig = []
+      expect(subject.
+               generate_listeners_stanza(mockwatcher, mockConfig)).
+        to eql({})
+    end
+
+    it 'generates a cluster stanza for each listener cluster' do
+      mockConfig = []
+      expect(subject.
+               generate_clusters_stanza(mockwatcher, mockConfig)).
+        to eql({"name"=>"example_service", "connect_timeout"=>0.25, "type"=>"strict_dns", "lb_policy"=>"round_robin", "hosts"=>[{"socket_address"=>{"address"=>"somehost", "port"=>5555}}]})
+    end
+
+    it 'generates a cluster stanza for each listener cluster' do
+      mockConfig = []
+      expect(subject.
+               generate_clusters_stanza(mockwatcher_frontend_with_bind_address, mockConfig)).
+        to eql({"name"=>"example_service5",
+                "connect_timeout"=>0.25,
+                "type"=>"strict_dns",
+                "lb_policy"=>"round_robin",
+                "hosts"=>[
+                  {"socket_address"=>{"address"=>"somehost", "port"=>5555}},
+                  {"socket_address"=>{"address"=>"somehost2", "port"=>5555}}]})
+    end
+
+    it 'generates a config for one service' do
+      mockConfig = []
+      expect(subject.
+               generate_config([mockwatcher_frontend_with_bind_address])).
+        to eql({"static_resources"=>{"listeners"=>[{"address"=>{"socket_address"=>{"address"=>"127.0.0.3", "port_value"=>"9090"}}, "filter_chains"=>{"filters"=>[{"name"=>"envoy.tcp_proxy", "config"=>{"stat_prefix"=>"ingress_tcp", "cluster"=>"example_service5", "access_log"=>{"name"=>"envoy.file_access_log", "config"=>{"path"=>"/var/log/envoy"}}}}]}}], "clusters"=>[{"name"=>"example_service5", "connect_timeout"=>0.25, "type"=>"strict_dns", "lb_policy"=>"round_robin", "hosts"=>[{"socket_address"=>{"address"=>"somehost", "port"=>5555}}, {"socket_address"=>{"address"=>"somehost2", "port"=>5555}}]}], "admin"=>{"access_log_path"=>"/dev/null", "address"=>{"socket_address"=>{"address"=>"127.0.0.1", "port_value"=>"8001"}}}}})
+    end
+  end
+end
+
+

--- a/spec/support/minimum.conf.yaml
+++ b/spec/support/minimum.conf.yaml
@@ -17,6 +17,9 @@ services:
         - some_haproxy_server_option
       listen:
         - some_haproxy_listen_option
+    envoy:
+      port: 9090
+      bind_address: 'localhost'
 
 # settings for haproxy including the global config
 haproxy:
@@ -33,3 +36,14 @@ haproxy:
 # settings for the file output generator
 file_output:
   output_directory: "/tmp/synapse_file_output_test"
+
+# settings for Envoy
+envoy:
+  reload_command: "sudo service haproxy reload"
+  config_file_path: "/etc/haproxy/haproxy.cfg"
+  do_writes: false
+  do_reloads: false
+  do_socket: false
+  global:
+  defaults:
+


### PR DESCRIPTION
This is a basic configuration generator for Envoy. There are a few TODOs here but right now this `bundle`s, packages, and properly generates basic configurations. This is heavily based off the HAProxy config generator which might be worth reading. I wanted to open this now and get some early eyes on it while I'm doing some other rollout prep. 

:eyeglasses: @cshoe 